### PR TITLE
Enable codec2 support

### DIFF
--- a/ffmpeg.spec
+++ b/ffmpeg.spec
@@ -49,6 +49,7 @@
 %global _with_vapoursynth 1
 %global _with_vmaf        1
 %endif
+%global _with_codec2 1
 
 # flavor nonfree
 %if 0%{?_with_cuda:1}
@@ -134,6 +135,7 @@ Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 BuildRequires:  alsa-lib-devel
 BuildRequires:  AMF-devel
 BuildRequires:  bzip2-devel
+%{?_with_codec2:BuildRequires: codec2-devel}
 %{?_with_faac:BuildRequires: faac-devel}
 %{?_with_fdk_aac:BuildRequires: fdk-aac-devel}
 %{?_with_flite:BuildRequires: flite-devel}
@@ -327,6 +329,7 @@ Freeworld libavcodec to complement the distro counterparts
     %{!?_without_bluray:--enable-libbluray} \\\
     %{?_with_bs2b:--enable-libbs2b} \\\
     %{?_with_caca:--enable-libcaca} \\\
+    %{?_with_codec2:--enable-libcodec2} \\\
     %{?_with_cuda_nvcc:--enable-cuda-nvcc --enable-nonfree} \\\
     %{?_with_cuvid:--enable-cuvid --enable-nonfree} \\\
     %{!?_without_cdio:--enable-libcdio} \\\


### PR DESCRIPTION
I'm not sure if there's a reason why codec2 support is disabled, but I use it myself, and had to rebuild a modified version of the rpmfusion package from source in order to enable it in Fedora.

With these three lines added to the .spec file, it works on my machine (built in mock and installed modified package). It would be nice if rpmfusion enabled codec2 support so that I didn't have to rebuild my custom version with each new update.