### PR TITLE
Rebuild for dav1d SONAME bump

### DIFF
--- a/ffmpeg.spec
+++ b/ffmpeg.spec
@@ -113,7 +113,7 @@ ExclusiveArch: armv7hnl
 Summary:        Digital VCR and streaming server
 Name:           ffmpeg%{?flavor}
 Version:        5.1.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        %{ffmpeg_license}
 URL:            https://ffmpeg.org/
 %if 0%{?date}
@@ -532,6 +532,9 @@ strip %{buildroot}%{_libdir}/%{name}/libavcodec.so.*
 
 
 %changelog
+* Wed Nov 20 2024 Alex Hughes <ahughesalex@gmail.com> - 5.1.6-2
+- Rebuild for dav1d SONAME bump
+
 * Mon Aug 05 2024 Leigh Scott <leigh123linux@gmail.com> - 5.1.6-1
 - Update to 5.1.6
 


### PR DESCRIPTION
EPEL has updated to libdav1d-1.5.0-2.el9.x86_64.rpm which is libdav1d.so.7.0.0

I assume this is the process of updating the package to point to libdav1d.so.7?